### PR TITLE
Upstream merge

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,58 +1,73 @@
 {
-  "name": "delennerd/wpemerge",
-  "description": "A micro framework which modernizes WordPress as a CMS development by providing tools to implement MVC and more.",
-  "type": "library",
-  "keywords": ["wordpress", "framework", "controller", "template", "view", "request", "response", "middleware", "wpemerge"],
-  "license": "GPL-2.0-only",
-  "homepage": "https://wpemerge.com/",
-  "authors": [
-	{
-      "name": "Pascal Lehnert",
-      "email": "hallo@pascal-lehnert.de",
-      "role": "Developer"
-    },
-    {
-      "name": "Atanas Angelov",
-      "email": "hi@atanas.dev",
-      "homepage": "https://atanas.dev/",
-      "role": "Creator"
-    },
-    {
-      "name": "htmlBurger",
-      "email": "info@htmlburger.com",
-      "homepage": "http://htmlburger.com/",
-      "role": "Creator"
-    }
-  ],
-  "support": {
-    "source": "https://github.com/htmlburger/wpemerge",
-    "issues": "https://github.com/htmlburger/wpemerge/issues",
-    "email": "wordpress@htmlburger.com"
-  },
-  "require": {
-    "php": ">=8.0",
-    "pimple/pimple": "^3.5",
-    "guzzlehttp/psr7": "^2.6",
-    "psr/container": "^2.0.1"
-  },
-  "require-dev": {
-    "filp/whoops": "^2.15",
-    "squizlabs/php_codesniffer": "^3",
-    "phpcompatibility/php-compatibility": "^9",
-    "mockery/mockery": "^0.9.11|~1.3.2"
-  },
-  "autoload": {
-    "psr-4": {
-      "WPEmerge\\": "src/",
-      "WPEmergeTestTools\\": "tests/tools"
-    },
-    "files": [
-      "config.php"
-    ]
-  },
-  "scripts": {
-    "lint": "phpcs",
-    "install-test-env": "WPEMERGE_PHP_VER=$(php -r 'echo PHP_MAJOR_VERSION . \".\" . PHP_MINOR_VERSION;') && if [ \"$WPEMERGE_PHP_VER\" \\> \"7.1\" ] && [ \"$WPEMERGE_PHP_VER\" \\< \"8.0\" ]; then composer require --dev phpunit/phpunit:^7 yoast/phpunit-polyfills; else composer require --dev phpunit/phpunit yoast/phpunit-polyfills; fi",
-    "test": "phpunit --coverage-clover=./tmp/clover.xml"
-  }
+	"name": "dieetplaneet/wpemerge",
+	"description": "A micro framework which modernizes WordPress as a CMS development by providing tools to implement MVC and more.",
+	"type": "library",
+	"keywords": [
+		"wordpress",
+		"framework",
+		"controller",
+		"template",
+		"view",
+		"request",
+		"response",
+		"middleware",
+		"wpemerge"
+	],
+	"license": "GPL-2.0-only",
+	"homepage": "https://wpemerge.com/",
+	"authors": [
+		{
+			"name": "Georgi Georgiev",
+			"email": "georgi@dieetplaneet.nl",
+			"role": "Developer"
+		},
+		{
+			"name": "Pascal Lehnert",
+			"email": "hallo@pascal-lehnert.de",
+			"role": "Developer"
+		},
+		{
+			"name": "Atanas Angelov",
+			"email": "hi@atanas.dev",
+			"homepage": "https://atanas.dev/",
+			"role": "Creator"
+		},
+		{
+			"name": "htmlBurger",
+			"email": "info@htmlburger.com",
+			"homepage": "http://htmlburger.com/",
+			"role": "Creator"
+		}
+	],
+	"support": {
+		"source": "https://github.com/htmlburger/wpemerge",
+		"issues": "https://github.com/htmlburger/wpemerge/issues",
+		"email": "wordpress@htmlburger.com"
+	},
+	"require": {
+		"php": ">=8.0",
+		"pimple/pimple": "^3.5",
+		"guzzlehttp/psr7": "^2.6",
+		"psr/container": "^2.0.1"
+	},
+	"require-dev": {
+		"filp/whoops": "^2.15",
+		"squizlabs/php_codesniffer": "^3",
+		"phpcompatibility/php-compatibility": "^9",
+		"mockery/mockery": "^0.9.11|~1.3.2"
+	},
+	"autoload": {
+		"psr-4": {
+			"WPEmerge\\": "src/",
+			"WPEmergeTestTools\\": "tests/tools"
+		},
+		"files": [
+			"config.php"
+		]
+	},
+	"scripts": {
+		"lint": "phpcs",
+		"install-test-env": "WPEMERGE_PHP_VER=$(php -r 'echo PHP_MAJOR_VERSION . \".\" . PHP_MINOR_VERSION;') && if [ \"$WPEMERGE_PHP_VER\" \\> \"7.1\" ] && [ \"$WPEMERGE_PHP_VER\" \\< \"8.0\" ]; then composer require --dev phpunit/phpunit:^7 yoast/phpunit-polyfills; else composer require --dev phpunit/phpunit yoast/phpunit-polyfills; fi",
+		"test": "phpunit --coverage-clover=./tmp/clover.xml"
+	}
 }

--- a/composer.json
+++ b/composer.json
@@ -1,73 +1,58 @@
 {
-	"name": "dieetplaneet/wpemerge",
-	"description": "A micro framework which modernizes WordPress as a CMS development by providing tools to implement MVC and more.",
-	"type": "library",
-	"keywords": [
-		"wordpress",
-		"framework",
-		"controller",
-		"template",
-		"view",
-		"request",
-		"response",
-		"middleware",
-		"wpemerge"
-	],
-	"license": "GPL-2.0-only",
-	"homepage": "https://wpemerge.com/",
-	"authors": [
-		{
-			"name": "Georgi Georgiev",
-			"email": "georgi@dieetplaneet.nl",
-			"role": "Developer"
-		},
-		{
-			"name": "Pascal Lehnert",
-			"email": "hallo@pascal-lehnert.de",
-			"role": "Developer"
-		},
-		{
-			"name": "Atanas Angelov",
-			"email": "hi@atanas.dev",
-			"homepage": "https://atanas.dev/",
-			"role": "Creator"
-		},
-		{
-			"name": "htmlBurger",
-			"email": "info@htmlburger.com",
-			"homepage": "http://htmlburger.com/",
-			"role": "Creator"
-		}
-	],
-	"support": {
-		"source": "https://github.com/htmlburger/wpemerge",
-		"issues": "https://github.com/htmlburger/wpemerge/issues",
-		"email": "wordpress@htmlburger.com"
-	},
-	"require": {
-		"php": ">=8.0",
-		"pimple/pimple": "^3.5",
-		"guzzlehttp/psr7": "^2.6",
-		"psr/container": "^2.0.1"
-	},
-	"require-dev": {
-		"filp/whoops": "^2.15",
-		"squizlabs/php_codesniffer": "^3",
-		"phpcompatibility/php-compatibility": "^9",
-		"mockery/mockery": "^0.9.11|~1.3.2"
-	},
-	"autoload": {
-		"psr-4": {
-			"WPEmerge\\": "src/",
-			"WPEmergeTestTools\\": "tests/tools"
-		},
-		"files": [
-			"config.php"
-		]
-	},
-	"scripts": {
-		"lint": "phpcs",
-		"install-test-env": "WPEMERGE_PHP_VER=$(php -r 'echo PHP_MAJOR_VERSION . \".\" . PHP_MINOR_VERSION;') && if [ \"$WPEMERGE_PHP_VER\" \\> \"7.1\" ] && [ \"$WPEMERGE_PHP_VER\" \\< \"8.0\" ]; then composer require --dev phpunit/phpunit:^7 yoast/phpunit-polyfills; else composer require --dev phpunit/phpunit yoast/phpunit-polyfills; fi",
-		"test": "phpunit --coverage-clover=./tmp/clover.xml"
-	}
+  "name": "delennerd/wpemerge",
+  "description": "A micro framework which modernizes WordPress as a CMS development by providing tools to implement MVC and more.",
+  "type": "library",
+  "keywords": ["wordpress", "framework", "controller", "template", "view", "request", "response", "middleware", "wpemerge"],
+  "license": "GPL-2.0-only",
+  "homepage": "https://wpemerge.com/",
+  "authors": [
+	{
+      "name": "Pascal Lehnert",
+      "email": "hallo@pascal-lehnert.de",
+      "role": "Developer"
+    },
+    {
+      "name": "Atanas Angelov",
+      "email": "hi@atanas.dev",
+      "homepage": "https://atanas.dev/",
+      "role": "Creator"
+    },
+    {
+      "name": "htmlBurger",
+      "email": "info@htmlburger.com",
+      "homepage": "http://htmlburger.com/",
+      "role": "Creator"
+    }
+  ],
+  "support": {
+    "source": "https://github.com/htmlburger/wpemerge",
+    "issues": "https://github.com/htmlburger/wpemerge/issues",
+    "email": "wordpress@htmlburger.com"
+  },
+  "require": {
+    "php": ">=8.0",
+    "pimple/pimple": "^3.5",
+    "guzzlehttp/psr7": "^2.6",
+    "psr/container": "^2.0.1"
+  },
+  "require-dev": {
+    "filp/whoops": "^2.15",
+    "squizlabs/php_codesniffer": "^3",
+    "phpcompatibility/php-compatibility": "^9",
+    "mockery/mockery": "^0.9.11|~1.3.2"
+  },
+  "autoload": {
+    "psr-4": {
+      "WPEmerge\\": "src/",
+      "WPEmergeTestTools\\": "tests/tools"
+    },
+    "files": [
+      "config.php"
+    ]
+  },
+  "scripts": {
+    "lint": "phpcs",
+    "install-test-env": "WPEMERGE_PHP_VER=$(php -r 'echo PHP_MAJOR_VERSION . \".\" . PHP_MINOR_VERSION;') && if [ \"$WPEMERGE_PHP_VER\" \\> \"7.1\" ] && [ \"$WPEMERGE_PHP_VER\" \\< \"8.0\" ]; then composer require --dev phpunit/phpunit:^7 yoast/phpunit-polyfills; else composer require --dev phpunit/phpunit yoast/phpunit-polyfills; fi",
+    "test": "phpunit --coverage-clover=./tmp/clover.xml"
+  }
 }

--- a/src/Application/LoadsServiceProvidersTrait.php
+++ b/src/Application/LoadsServiceProvidersTrait.php
@@ -109,6 +109,6 @@ trait LoadsServiceProvidersTrait {
 			$provider->bootstrap( $container );
 		}
 
-		do_action( 's' );
+		do_action( 'wpemerge.providers.bootstraped' );
 	}
 }

--- a/src/Application/LoadsServiceProvidersTrait.php
+++ b/src/Application/LoadsServiceProvidersTrait.php
@@ -93,6 +93,8 @@ trait LoadsServiceProvidersTrait {
 		foreach ( $service_providers as $provider ) {
 			$provider->register( $container );
 		}
+
+		do_action( 'wpemerge.providers.registered' );
 	}
 
 	/**
@@ -106,5 +108,7 @@ trait LoadsServiceProvidersTrait {
 		foreach ( $service_providers as $provider ) {
 			$provider->bootstrap( $container );
 		}
+
+		do_action( 's' );
 	}
 }

--- a/src/Application/LoadsServiceProvidersTrait.php
+++ b/src/Application/LoadsServiceProvidersTrait.php
@@ -109,6 +109,6 @@ trait LoadsServiceProvidersTrait {
 			$provider->bootstrap( $container );
 		}
 
-		do_action( 'wpemerge.providers.bootstraped' );
+		do_action( 'wpemerge.providers.bootstrapped' );
 	}
 }


### PR DESCRIPTION
Hi,
I'm starting self-support of WpEmerge too, as it seems abandoned. Would like to collaborate should you accept. Here's an addition - do_action added after all providers registered and all providers bootstrapped. Useful to perform some post-processing, imo. I use those extensively in my plugin, but till now I was overriding the LoadsServiceProvidersTrait. Now as I'm starting to make changes - I put these right in the framework itself.
